### PR TITLE
[workaround] Make context derived from environment variables optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tencent_scf"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Youmu <johnmave126@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "Custom runtime for Tencent cloud serverless compute function"

--- a/examples/biliplus-proxy/Cargo.toml
+++ b/examples/biliplus-proxy/Cargo.toml
@@ -11,5 +11,5 @@ path = "src/main.rs"
 
 [dependencies]
 ureq = "2.1.0"
-tencent_scf = { version = "0.2.0", features = ["builtin-api-gateway"], path = "../../" }
+tencent_scf = { version = "0.3.0", features = ["builtin-api-gateway"], path = "../../" }
 thiserror = "1.0.24"


### PR DESCRIPTION
In last month, two things happens:
* `SCF_NAMESPACE` has been removed from the list of guaranteed environment variables in the documentation.
* With such change, almost all `SCF_*` and `TENCENTCLOUD_*` environment variables, even those still in the documentation, disappeared from the running environment for Hongkong region.

I don't think it is a good practice to remove something from running environment. And it baffles me that they could f**k up with basic environment variable settings. So I need to play safe. I am now making all context variables that are derived from the environment variables `Option<&str>` to mitigate current and possibly future breakage.